### PR TITLE
fix: remove arlac77/npm-template-sync-github-hook

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,7 +57,6 @@
       "arlac77/npm-pkgbuild",
       "arlac77/npm-pkgbuild#multi_format",
       "arlac77/npm-template-sync",
-      "arlac77/npm-template-sync-github-hook",
       "arlac77/one-time-execution-method",
       "arlac77/pratt-parser",
       "arlac77/reader-line-iterator",


### PR DESCRIPTION
fix: remove arlac77/npm-template-sync-github-hook